### PR TITLE
Update revocation status structure, nested claims and PID 1.5

### DIFF
--- a/pymdoccbor/mso/issuer.py
+++ b/pymdoccbor/mso/issuer.py
@@ -170,7 +170,7 @@ class MsoIssuer(MsoX509Fabric):
         }
 
         if self.revocation is not None:
-            payload.update({"status": {"StatusListInfo": self.revocation}})
+            payload.update({"status": self.revocation})
 
         if self.cert_path:
             # Load the DER certificate file

--- a/pymdoccbor/mso/issuer.py
+++ b/pymdoccbor/mso/issuer.py
@@ -98,12 +98,13 @@ class MsoIssuer(MsoX509Fabric):
                     v = cbor2.CBORTag(_value_cbortag, value=v)
                     # print("\n-----\n K,V ", k, "\n", v)
 
-                if (
-                    k == "driving_privileges"
-                    or k == "places_of_work"
-                    or k == "legislation"
-                    or k == "employment_details"
-                ):
+                if isinstance(v, dict):
+                    for k2, v2 in v.items():
+                        _value_cbortag = settings.CBORTAGS_ATTR_MAP.get(k2, None)
+                        if _value_cbortag:
+                            v[k2] = cbor2.CBORTag(_value_cbortag, value=v2)
+
+                if isinstance(v, list):
                     for item in v:
                         for k2, v2 in item.items():
                             _value_cbortag = settings.CBORTAGS_ATTR_MAP.get(k2, None)

--- a/pymdoccbor/mso/issuer.py
+++ b/pymdoccbor/mso/issuer.py
@@ -98,7 +98,12 @@ class MsoIssuer(MsoX509Fabric):
                     v = cbor2.CBORTag(_value_cbortag, value=v)
                     # print("\n-----\n K,V ", k, "\n", v)
 
-                if k == "driving_privileges":
+                if (
+                    k == "driving_privileges"
+                    or k == "places_of_work"
+                    or k == "legislation"
+                    or k == "employment_details"
+                ):
                     for item in v:
                         for k2, v2 in item.items():
                             _value_cbortag = settings.CBORTAGS_ATTR_MAP.get(k2, None)

--- a/pymdoccbor/mso/issuer.py
+++ b/pymdoccbor/mso/issuer.py
@@ -104,7 +104,7 @@ class MsoIssuer(MsoX509Fabric):
                         if _value_cbortag:
                             v[k2] = cbor2.CBORTag(_value_cbortag, value=v2)
 
-                if isinstance(v, list):
+                if isinstance(v, list) and k != "nationality":
                     for item in v:
                         for k2, v2 in item.items():
                             _value_cbortag = settings.CBORTAGS_ATTR_MAP.get(k2, None)

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
     install_requires=[
         "cbor2>=5.4.0,<5.5.0",
         "cwt>=2.3.0,<2.4",
+        #'pycose>=1.0.1,<1.1.0'
         "pycose @ git+https://github.com/devisefutures/pycose.git@hsm",
     ],
 )


### PR DESCRIPTION
- StatusListInfo is deprecated in the revocation structure.
- deal with nested claims dictionary parsing
- list nationality to remain as a list. 